### PR TITLE
Use "py -3" instead of "python"

### DIFF
--- a/views/help.pug
+++ b/views/help.pug
@@ -49,7 +49,7 @@ include includes/base
         li Download or find your #[code movable_part1.sed] file and copy it to the #[code seedminer] folder.
         li Rename the file to #[code movable_part1.sed] if it is not already named that.
         li Open a command prompt in the seedminer folder by shift-right clicking inside it and clicking 'Open command window here' or 'Open PowerShell window here'.
-        li Run #[code python seedminer_launcher3.py gpu].
+        li Run #[code py -3 seedminer_launcher3.py gpu].
         li Wait for the process to complete. It can take at least 20 minutes and possibly hours depending on the power of your GPU.
         li Find your #[code movable.sed] file in the #[code seedminer] folder.
     

--- a/views/work.pug
+++ b/views/work.pug
@@ -71,7 +71,7 @@ include includes/base
                 li Run #[code pip install requests].
                 b When you want to help
                 li Open a command prompt in the seedminer folder by shift-right clicking inside it and clicking 'Open command window here' or 'Open PowerShell window here'.
-                li Run #[code python seedminer_autolauncher.py].
+                li Run #[code py -3 seedminer_autolauncher.py].
                 li You may be prompted for login details.
                 li Once you first see "Finding work..." then you can leave the script running.
                 li If you want to stop, just press Ctrl+C in the first command prompt to stop working at any time.
@@ -90,7 +90,7 @@ include includes/base
                 li Download the file provided to your computer and copy it to the #[code seedminer] folder.
                 li Rename the file to #[code movable_part1.sed].
                 li Open a command prompt in the seedminer folder by shift-right clicking inside it and clicking 'Open command window here' or 'Open PowerShell window here'.
-                li Run #[code python seedminer_launcher3.py gpu].
+                li Run #[code py -3 seedminer_launcher3.py gpu].
                 li Upload #[code movable.sed] and the msed_data file listed by the script to the website once complete.
                 li Delete #[code movable_part1.sed] and #[code movable.sed] from the #[code seedminer] folder on your computer.
             a.pure-button.pure-button-primary(href="/work/movables") Start working


### PR DESCRIPTION
The `python` command is the old way of running Python on Windows. It only runs a single version (and it could be any version), and has to be added to PATH explicitly, either at setup or manually.

The `py` launcher on Windows is always enabled by default (meaning a user would have to explicitly disable it at install to not get it), and it can launch multiple different versions, such as `py -2`, `py -3`, `py -2.7`, and `py -3.6`.

https://docs.python.org/3/using/windows.html#launcher